### PR TITLE
Fix for people who use this in their apps while coding offline

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -41,6 +41,9 @@ class Statsd
 
   def send(stat, delta, type, sample_rate)
     sampled(sample_rate) { socket.send("#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}", 0, @host, @port) }
+  rescue SocketError => e
+    # Don't raise errors on the socket.  We use UDP since we don't care whether or not the message went through.
+    puts "Unable to initialize socket to send data."
   end
 
   def socket; @socket ||= UDPSocket.new end


### PR DESCRIPTION
This is mainly a fix for people who are coding when not on the internet.  Ruby's socket will raise on getaddrinfo which doesn't work when your computer isn't connected to a network.

I catch SocketError during the send process so that we don't needlessly blow up the app.  The gem itself uses UDP anyway so we don't really care what the response was when we were initializing the socket.  Any normal code-related errors will still raise.
